### PR TITLE
This is not currently an evolving list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Here we're collecting a list of the components, tools and services that we've used at the Government Digital Service to build [GOV.UK](https://www.gov.uk/).
 
-Included here are snapshots of our stack at key releases, such as the [alpha](https://github.com/alphagov/colophon/blob/master/alpha.md) and [beta](https://github.com/alphagov/colophon/blob/master/beta.md), and an evolving list of components for the [live site](https://github.com/alphagov/colophon/blob/master/live.md).
+Included here are snapshots of our stack at key releases, such as the [alpha](https://github.com/alphagov/colophon/blob/master/alpha.md) and [beta](https://github.com/alphagov/colophon/blob/master/beta.md), and 18 months into the [live site](https://github.com/alphagov/colophon/blob/master/live.md).


### PR DESCRIPTION
This commit changes the README to indicate that the current `live.md` is a snapshot from March 2014 rather than an evolving list. I know @timblair has plans to update this and keep it current, but I'm about to link to it in a blog post so would like to make it clear what the current state is.